### PR TITLE
Merge LED User Diagnostics into main

### DIFF
--- a/Sketchbooks/Obsolete/featherDIYv4_rapidstart_continuous_v1/SparkFun_MS5803_I2C.cpp
+++ b/Sketchbooks/Obsolete/featherDIYv4_rapidstart_continuous_v1/SparkFun_MS5803_I2C.cpp
@@ -231,13 +231,12 @@ uint32_t MS5803::getADCconversion(measurement _measurement, precision _precision
 	switch (_precision) {
 	case ADC_256:
 		sensorWait(1);
-
 		break;
 	case ADC_512:
-		sensorWait(2);
+		sensorWait(3);
 		break;
 	case ADC_1024:
-		sensorWait(3);
+		sensorWait(4);
 		break;
 	case ADC_2048:
 		sensorWait(6);

--- a/Sketchbooks/Obsolete/featherDIYv4_rapidstart_continuous_v1/SparkFun_MS5803_I2C.h
+++ b/Sketchbooks/Obsolete/featherDIYv4_rapidstart_continuous_v1/SparkFun_MS5803_I2C.h
@@ -1,0 +1,106 @@
+/******************************************************************************
+MS5803_I2C.h
+Library for MS5803 pressure sensors.
+Casey Kuhns @ SparkFun Electronics
+6/26/2014
+https://github.com/sparkfun/MS5803-14BA_Breakout
+
+The MS58XX MS57XX and MS56XX by Measurement Specialties is a low cost I2C pressure
+sensor.  This sensor can be used in weather stations and for altitude
+estimations. It can also be used underwater for water depth measurements.
+
+In this file are the function prototypes in the MS5803 class
+
+Resources:
+This library uses the Arduino Wire.h to complete I2C transactions.
+
+Development environment specifics:
+	IDE: Arduino 1.0.5
+	Hardware Platform: Arduino Pro 3.3V/8MHz
+	MS5803 Breakout Version: 1.0
+
+**Updated for Arduino 1.6.4 5/2015**
+
+License: Please see LICENSE.md for more details.
+
+Distributed as-is; no warranty is given.
+******************************************************************************/
+
+#ifndef SparkFun_MS5803_I2C_h
+#define SparkFun_MS5803_I2C_h
+
+#include <Arduino.h>
+#include "Wire.h"
+#include "avr/power.h"
+
+// Define units for conversions.
+enum temperature_units {
+	CELSIUS,
+	FAHRENHEIT,
+};
+
+// Define measurement type.
+enum measurement {
+	PRESSURE = 0x00,
+	TEMPERATURE = 0x10
+};
+
+// Define constants for Conversion precision
+enum precision {
+	ADC_256 = 0x00,
+	ADC_512 = 0x02,
+	ADC_1024 = 0x04,
+	ADC_2048 = 0x06,
+	ADC_4096 = 0x08
+};
+
+// Define address choices for the device (I2C mode)
+enum ms5803_addr {
+	ADDRESS_HIGH = 0x76,
+	ADDRESS_LOW = 0x77
+};
+
+// Commands
+#define CMD_RESET 0x1E	  // reset command
+#define CMD_ADC_READ 0x00 // ADC read command
+#define CMD_ADC_CONV 0x40 // ADC conversion command
+
+#define CMD_PROM 0xA0 // Coefficient location
+
+class MS5803 {
+public:
+   volatile bool sensorWaitDone; // Flag for ISR sensor wait
+   static MS5803 *activeSensor; // Static pointer for ISR access
+
+	MS5803(ms5803_addr address = ADDRESS_HIGH);
+	void reset(void);								   // Reset device
+	uint8_t begin(TwoWire &wirePort = Wire);		   // Collect coefficients from sensor
+	uint8_t begin(TwoWire &wirePort, uint8_t address); // Collect coefficients from sensor
+
+	// Return calculated temperature from sensor
+	float getTemperature(temperature_units units, precision _precision);
+	// Return calculated pressure from sensor
+	float getPressure(precision _precision);
+
+   // Use to get temperature and pressure when both are desired at the same time. Updates associated float* values with new data
+   void getSensorReadings(temperature_units units, precision _precision_pres, precision _precision_temp, float *currentPressure, float *currentTemperature);
+
+private:
+	int32_t _temperature_actual;
+	int32_t _pressure_actual;
+
+	TwoWire *_i2cPort = nullptr; // The generic connection to user's chosen I2C hardware
+	uint8_t _address;			 // Variable used to store I2C device address.
+	uint16_t coefficient[8];	 // Coefficients;
+
+	void getMeasurements(precision _precision);
+
+	void sendCommand(uint8_t command);										   // General I2C send command function
+	uint32_t getADCconversion(measurement _measurement, precision _precision); // Retrieve ADC result
+
+	void sensorWait(uint8_t time); // General delay function see: delay()
+
+   static void sensorWaitInterrupt(); // Interrupt telling MCU to end sensor wait time has elapsed
+};
+
+#endif

--- a/Sketchbooks/feathergauge_code/feathergauge_code.ino
+++ b/Sketchbooks/feathergauge_code/feathergauge_code.ino
@@ -3,29 +3,35 @@
 // add interrupt detaches
 
 // ===========================
-// USER-DEFINED FLAGS: 
+// USER DEFINED FLAGS: 
 // Please set the following three flags according to your sensor type and preferred collection type.
+// Type "true" (without quotes) or "false" (without quotes)
 // ===========================
 
 // Set to true for MS5837 (new pressure sensor)
 // Set to false for MS5803 (old pressure sensor)
+// RAPID users should always set this to false
 #define USE_NEW_SENSOR               false
 
 // Set to false for rapid start
 // Set to true for delayed start, using selected start date
+// Untested, DO NOT USE. Set to "false"
 #define DELAY_START                  false
 
 // Set to true for burst sampling
 // Set to false for constant sampling
-#define BURST_SAMPLING               true
+#define BURST_SAMPLING               false
 
-#define BURST_SAMPLING_ONE_SAMPLE    true
+// Set to true if only one sample should be taken at each burst
+// Set to false if samples should be taken according to SAMPLE_FREQ during the
+// write period
+#define BURST_SAMPLING_ONE_SAMPLE    false
 
 // ===========================
 // USER INPUTS:
 // Please set the below variables to reflect your sampling preferences.
 // ===========================
-#define SAMPLE_FREQ                   1        // Sampling frequency in Hz
+#define SAMPLE_FREQ                   4         // Sampling frequency in Hz
 
 // Burst sampling alternates between writing and sleeping according to set periods below
 const uint8_t writeSeconds = 5;    // Number of seconds to sample data in burst sampling
@@ -48,7 +54,9 @@ const uint8_t sleepSeconds = 120;   // Number of seconds to sleep in burst sampl
   const int startMinute = 0;    // DO NOT MODIFY
 #endif
 
-// =========================== USER: DO NOT EDIT BELOW THIS LINE ===========================
+// =========================================================================================
+// ======================= !!! USER: DO NOT EDIT BELOW THIS LINE !!! =======================
+// =========================================================================================
 
 // ===========================
 // LIBRARIES
@@ -117,6 +125,9 @@ class CustomMS5803 : public MS5803 {
 #define ERROR_PAUSE_DELAY             200     // Pause between error blink cycles (ms)
 #define ERROR_BLINK_CYCLE             10      // Total blinks per error cycle
 
+const uint8_t LED_WARMUP_DEFAULT_FLASHES = 5;
+const uint16_t LED_WARMUP_MANUAL_FLASH_DELAY_MS = 500;
+
 // ADC and voltage definitions
 #define MAX_ADC_VALUE                 1024    // Maximum ADC reading (10-bit resolution)
 #define REFERENCE_VOLTAGE             3.3     // ADC reference voltage (V)
@@ -124,7 +135,7 @@ class CustomMS5803 : public MS5803 {
 
 // Buffer and data definitions
 #define BUFFER_SIZE                   36      // Circular buffer size (limited by 32u4 SRAM, only 2560 bytes)
-#define BUFFER_WRITE_COUNT            5       // Buffer and data definitions 32
+#define BUFFER_WRITE_COUNT            32       // Buffer and data definitions 32
 #define FILENAME_LENGTH               13      // Filename length, limited by FAT16 filesystem to 8.3 format (13th char for null terminator)
 #define FRESHWATER_DENSITY            997     // Freshwater density (kg/m³) for pressure calculations
 #define SALTWATER_DENSITY            1025     // Saltwater density (kg/m³) for pressure calculations
@@ -183,6 +194,15 @@ volatile bool sleeping       = false;
 
 unsigned long millisAtInterrupt = 0; // Number of milliseconds at last 1 Hz interrupt from RTC
 
+// # of times the LED should be toggled (switched between on/off) during the start-up verification phase
+uint8_t ledWarmupToggleTarget = 0;
+
+// Current # of times the LED has been toggled
+uint8_t ledWarmupToggleCount  = 0;
+
+// True if LED should be toggled only once (blocking for LED_WARMUP_MANUAL_FLASH_DELAY_MS) during start-up
+bool ledWarmupManualPulsePending = false;
+
 // ===========================
 // SETUP - SENSOR, TIMESTAMP, SD CARD
 // ===========================
@@ -191,14 +211,15 @@ void setup() {
   power_timer3_disable();
   power_timer4_disable();
   pinMode(LED_PIN, OUTPUT); // Activates the red LED on pin 13
+  configureLedWarmupIndicator();
   pinMode(RTC_INTERRUPT_PIN, INPUT_PULLUP);
-  Serial.begin(SERIAL_BAUD_RATE);
-  while (!Serial); 
+  // Serial.begin(SERIAL_BAUD_RATE);  // Commented out to prevent blocking when USB disconnected
+  // while (!Serial);  // Removed to prevent blocking when USB disconnected 
   Wire.begin();
   Wire.setClock(TWI_CLOCK_SPEED);
   
   if (!rtc.begin()) {
-    Serial.println(F("RTC Failed to initialize"));
+    if (Serial) Serial.println(F("RTC Failed to initialize"));
     error(2);
     return;
   }
@@ -215,18 +236,20 @@ void setup() {
         // If the DS3231 has had continous MCU/battery power since last program flash, the time will not be changed
         rtc.adjust(DateTime(F(__DATE__), F(__TIME__)));
         DateTime setTime = rtc.now();
-        Serial.print(F("RTC time set to: "));
-        Serial.print(setTime.year());
-        Serial.print('/');
-        Serial.print(setTime.month());
-        Serial.print('/');
-        Serial.print(setTime.day());
-        Serial.print(' ');
-        Serial.print(setTime.hour());
-        Serial.print(':');
-        Serial.print(setTime.minute());
-        Serial.print(':');
-        Serial.println(setTime.second());
+        if (Serial) {
+          Serial.print(F("RTC time set to: "));
+          Serial.print(setTime.year());
+          Serial.print('/');
+          Serial.print(setTime.month());
+          Serial.print('/');
+          Serial.print(setTime.day());
+          Serial.print(' ');
+          Serial.print(setTime.hour());
+          Serial.print(':');
+          Serial.print(setTime.minute());
+          Serial.print(':');
+          Serial.println(setTime.second());
+        }
   }
 
   currentSecond = rtc.now();
@@ -235,7 +258,7 @@ void setup() {
   
   #if USE_NEW_SENSOR
     if (!newSensor.init()) {
-      Serial.println("New pressure sensor failed to initialize");
+      if (Serial) Serial.println("New pressure sensor failed to initialize");
       error(3);
       return;
     }
@@ -246,10 +269,10 @@ void setup() {
     oldSensor.begin();
   #endif
 
-    Serial.print(F("Initializing SD card..."));
+    if (Serial) Serial.print(F("Initializing SD card..."));
   
   if (!SD.begin(SD_CARD_SELECT_PIN)) { 
-    Serial.println(F("Card Failed or Not Present"));
+    if (Serial) Serial.println(F("Card Failed or Not Present"));
     error(ERROR_SD_CARD_FAILED);
     return;
   }
@@ -258,7 +281,7 @@ void setup() {
     dataBuffer[i].valid = false;
   }
 
-  Serial.println(F("Card Initialized."));
+  if (Serial) Serial.println(F("Card Initialized."));
   char fileName[FILENAME_LENGTH];
   makeFileName(fileName);
   
@@ -266,7 +289,7 @@ void setup() {
   outputFile = SD.open(fileName, FILE_WRITE); // Opens .csv file
 
   if (outputFile) {
-    Serial.println(F("File opened"));
+    if (Serial) Serial.println(F("File opened"));
     char serialNumber[16];
     EEPROM.get(SERIAL_NUMBER_ADDRESS, serialNumber);
     outputFile.print(F("W.G. Num: "));
@@ -276,7 +299,7 @@ void setup() {
     outputFile.println();
     outputFile.flush();
   } else {
-    Serial.println(F("error opening datalog-case1"));
+    if (Serial) Serial.println(F("error opening datalog-case1"));
     error(ERROR_FILE_OPEN_FAILED);
   }
 
@@ -297,12 +320,14 @@ void setup() {
     // Serial.println(F("READY!"));
     #if BURST_SAMPLING
       timeAtBurstSwitch = rtc.now();
-      Serial.print(F("[BURST] Start write window at "));
-      Serial.print(timeAtBurstSwitch.hour()); Serial.print(':');
-      Serial.print(timeAtBurstSwitch.minute()); Serial.print(':');
-      Serial.println(timeAtBurstSwitch.second());
-      Serial.print(F("[BURST] writeSeconds=")); Serial.print(writeSeconds);
-      Serial.print(F(", sleepSeconds=")); Serial.println(sleepSeconds);
+      if (Serial) {
+        Serial.print(F("[BURST] Start write window at "));
+        Serial.print(timeAtBurstSwitch.hour()); Serial.print(':');
+        Serial.print(timeAtBurstSwitch.minute()); Serial.print(':');
+        Serial.println(timeAtBurstSwitch.second());
+        Serial.print(F("[BURST] writeSeconds=")); Serial.print(writeSeconds);
+        Serial.print(F(", sleepSeconds=")); Serial.println(sleepSeconds);
+      }
     #endif
   #endif
 }
@@ -327,10 +352,12 @@ void loop() {
           attachInterrupt(digitalPinToInterrupt(RTC_INTERRUPT_PIN), resetTimerInterrupt, FALLING);
         #endif
         resetTimer();
-        Serial.print(F("[BURST] Wake -> start write window at "));
-        Serial.print(timeAtBurstSwitch.hour()); Serial.print(':');
-        Serial.print(timeAtBurstSwitch.minute()); Serial.print(':');
-        Serial.println(timeAtBurstSwitch.second());
+        if (Serial) {
+          Serial.print(F("[BURST] Wake -> start write window at "));
+          Serial.print(timeAtBurstSwitch.hour()); Serial.print(':');
+          Serial.print(timeAtBurstSwitch.minute()); Serial.print(':');
+          Serial.println(timeAtBurstSwitch.second());
+        }
         burstSleepFlag = false;
       } else if (elapsed.totalseconds() > writeSeconds || BURST_SAMPLING_ONE_SAMPLE) {
         digitalWrite(LED_PIN, HIGH);
@@ -345,12 +372,14 @@ void loop() {
           writeToOutputFile(data.now, data.millisec, data.pressure, data.temperature, data.batteryVoltage);
         }
         outputFile.flush();
-        Serial.print(F("[BURST] End write window at "));
-        Serial.print(endTime.hour()); Serial.print(':');
-        Serial.print(endTime.minute()); Serial.print(':');
-        Serial.println(endTime.second());
-        Serial.print("Elapsed time: ");
-        Serial.println(elapsed.totalseconds());
+        if (Serial) {
+          Serial.print(F("[BURST] End write window at "));
+          Serial.print(endTime.hour()); Serial.print(':');
+          Serial.print(endTime.minute()); Serial.print(':');
+          Serial.println(endTime.second());
+          Serial.print("Elapsed time: ");
+          Serial.println(elapsed.totalseconds());
+        }
         enterBurstDeepSleep(endTime);
       }
     #endif
@@ -382,13 +411,17 @@ void loop() {
           samplingFlag = false;
         }
       }
-      Serial.print(F("Starting write at time: "));
-      Serial.println(millis());
+      if (Serial) {
+        Serial.print(F("Starting write at time: "));
+        Serial.println(millis());
+      }
       outputFile.flush();
-      Serial.print(F("Wrote "));
-      Serial.print(writeCount);
-      Serial.print(F(" data points to SD card at time "));
-      Serial.println(millis());
+      if (Serial) {
+        Serial.print(F("Wrote "));
+        Serial.print(writeCount);
+        Serial.print(F(" data points to SD card at time "));
+        Serial.println(millis());
+      }
     }
     // Finished writing to SD card, sleep until next sampling time or interrupt from timers/RTC
     // When waking from burst sleep, this idle command mean the MCU will sleep until the next ms, then check the flag
@@ -406,6 +439,7 @@ void loop() {
  * Usage: Called when `samplingFlag` is set or in one-sample burst mode.
  */
 void performSensorReading() {
+    float currentTemperature, currentPressure;
     #if USE_NEW_SENSOR
       newSensor.read();
       currentTemperature = newSensor.temperature();
@@ -413,6 +447,8 @@ void performSensorReading() {
     #else
       oldSensor.getSensorReadings(CELSIUS, ADC_4096, ADC_512, &currentPressure, &currentTemperature);
     #endif
+
+  updateLedWarmupIndicator();
 
     // Compute timestamp relative to last RTC tick without mutating global currentSecond
     uint16_t millisec = millis() - millisAtInterrupt;
@@ -453,18 +489,20 @@ void resetTimer() {
   power_adc_enable();
   millisAtInterrupt = millis();
   currentSecond = rtc.now();
-  Serial.print(F("Reset timer at: "));
-  Serial.print(currentSecond.year());
-  Serial.print('/');
-  Serial.print(currentSecond.month());
-  Serial.print('/');
-  Serial.print(currentSecond.day());
-  Serial.print(' ');
-  Serial.print(currentSecond.hour());
-  Serial.print(':');
-  Serial.print(currentSecond.minute());
-  Serial.print(':');
-  Serial.println(currentSecond.second());
+  if (Serial) {
+    Serial.print(F("Reset timer at: "));
+    Serial.print(currentSecond.year());
+    Serial.print('/');
+    Serial.print(currentSecond.month());
+    Serial.print('/');
+    Serial.print(currentSecond.day());
+    Serial.print(' ');
+    Serial.print(currentSecond.hour());
+    Serial.print(':');
+    Serial.print(currentSecond.minute());
+    Serial.print(':');
+    Serial.println(currentSecond.second());
+  }
   #if BURST_SAMPLING
     elapsed = currentSecond - timeAtBurstSwitch;
   #endif
@@ -511,8 +549,10 @@ void makeFileName(char* fileName) {
     fileName[7] = '0' + (fileIndex % 10);
   }
   
-  Serial.print(F("File name: "));
-  Serial.println(fileName);
+  if (Serial) {
+    Serial.print(F("File name: "));
+    Serial.println(fileName);
+  }
 }
 
 /**
@@ -596,7 +636,6 @@ void addToBuffer(DateTime now, int millisec, float pressure, float temperature, 
   } else {
     bufferCount++;
   }
-  
   dataBuffer[bufferHead].now = now;
   dataBuffer[bufferHead].millisec = millisec;
   dataBuffer[bufferHead].pressure = pressure;
@@ -700,7 +739,7 @@ void enterDelayDeepSleep() {
   attachInterrupt(digitalPinToInterrupt(RTC_INTERRUPT_PIN), deepSleepInterrupt, FALLING);
   rtc.setAlarm1(startDateTime, DS3231_A1_Date); // Alarm 1 triggers at the start time
   rtc.setAlarm2(startDateTime, DS3231_A2_Hour); // Alarm 2 triggers every day, taking a sample to track when/if battery dies
-  Serial.println(F("Entering delay deep sleep"));
+  if (Serial) Serial.println(F("Entering delay deep sleep"));
   LowPower.powerDown(SLEEP_FOREVER, ADC_OFF, BOD_OFF);
   // digitalWrite(LED_PIN, HIGH);
   // delay(1000);
@@ -732,10 +771,12 @@ void enterBurstDeepSleep(DateTime endTime) {
     return;
   }
   DateTime nextWake(endTime + TimeSpan(sleepSeconds));
-  Serial.print(F("[BURST] Next wake scheduled at "));
-  Serial.print(nextWake.hour()); Serial.print(':');
-  Serial.print(nextWake.minute()); Serial.print(':');
-  Serial.println(nextWake.second());
+  if (Serial) {
+    Serial.print(F("[BURST] Next wake scheduled at "));
+    Serial.print(nextWake.hour()); Serial.print(':');
+    Serial.print(nextWake.minute()); Serial.print(':');
+    Serial.println(nextWake.second());
+  }
   rtc.clearAlarm(1);
   rtc.setAlarm1(nextWake, DS3231_A1_Date);
   attachInterrupt(digitalPinToInterrupt(RTC_INTERRUPT_PIN), burstSleepInterrupt, FALLING);
@@ -746,7 +787,6 @@ void enterBurstDeepSleep(DateTime endTime) {
   Wire.end();
   Wire.begin();
   Wire.setClock(TWI_CLOCK_SPEED);
-  Serial.begin(SERIAL_BAUD_RATE);
   rtc.clearAlarm(1);
   timeAtBurstSwitch = rtc.now();
   resetTimer();
@@ -771,7 +811,7 @@ void setForeverIdleSleep() {
 // ===========================
 // ERRORS/TROUBLESHOOTING
 // ===========================
-// Triggers the LED on pin 13 to blink a certain number of times during unrecoverable errors
+
 /**
  * error
  * Purpose: Indicate unrecoverable error by blinking LED a number of times equal to `errno`, repeated forever.
@@ -791,6 +831,75 @@ void error (uint8_t errno) {
     for (blinkCount = errno; blinkCount < ERROR_BLINK_CYCLE; blinkCount++) {
       delay(ERROR_PAUSE_DELAY);
     }
+  }
+}
+
+/**
+ * configureLedWarmupIndicator
+ * Purpose: Set the correct number of flashes at start-up for the current configuration, used to verify
+ *          that the wave gauge is working correctly without serial port access.
+ * Inputs: None, configures global variables ledWarmupToggleCount, ledWarmupToggleTarget, ledWarmupManualPulsePending
+ * Usage: Run once within setup()
+ */
+void configureLedWarmupIndicator() {
+  ledWarmupToggleCount = 0;
+  ledWarmupToggleTarget = 0;
+  ledWarmupManualPulsePending = false;
+
+#if BURST_SAMPLING_ONE_SAMPLE
+  ledWarmupManualPulsePending = true;
+#else
+  uint8_t flashCount = LED_WARMUP_DEFAULT_FLASHES;
+  bool useManualPulse = false;
+  #if BURST_SAMPLING
+    uint32_t availableReadings = (uint32_t)writeSeconds * (uint32_t)SAMPLE_FREQ;
+    // Calculate # of flashes that fit within first sampling window
+    while (flashCount > 1 && ((uint32_t)flashCount * 2) > availableReadings) {
+      flashCount /= 2;
+      if (flashCount == 0) {
+        flashCount = 1;
+        break;
+      }
+    }
+    if (((uint32_t)flashCount * 2) > availableReadings) {
+      useManualPulse = true;
+    }
+  #endif
+  if (useManualPulse) {
+    ledWarmupManualPulsePending = true;
+  } else {
+    ledWarmupToggleTarget = flashCount * 2;
+  }
+#endif
+
+  digitalWrite(LED_PIN, LOW);
+}
+
+/**
+ * updateLedWarmupIndicator
+ * Purpose: Toggle LED_PIN at program start for a set number of sensor readings
+ * Inputs: None, uses global variables ledWarmupToggleCount, ledWarmupToggleTarget, ledWarmupManualPulsePending
+ * Usage: Run within performSensorReadings() if LED diagnostics are desired
+ */
+void updateLedWarmupIndicator() {
+  if (ledWarmupManualPulsePending) {
+    digitalWrite(LED_PIN, HIGH);
+    delay(LED_WARMUP_MANUAL_FLASH_DELAY_MS);
+    digitalWrite(LED_PIN, LOW);
+    ledWarmupManualPulsePending = false;
+    return;
+  }
+
+  if (ledWarmupToggleCount >= ledWarmupToggleTarget) {
+    return;
+  }
+
+  bool ledShouldBeOn = (ledWarmupToggleCount % 2 == 0);
+  digitalWrite(LED_PIN, ledShouldBeOn ? HIGH : LOW);
+  ledWarmupToggleCount++;
+
+  if (ledWarmupToggleCount >= ledWarmupToggleTarget) {
+    digitalWrite(LED_PIN, LOW);
   }
 }
 

--- a/Sketchbooks/feathergauge_code/feathergauge_code.ino
+++ b/Sketchbooks/feathergauge_code/feathergauge_code.ino
@@ -31,12 +31,12 @@
 // USER INPUTS:
 // Please set the below variables to reflect your sampling preferences.
 // ===========================
-#define SAMPLE_FREQ                   4         // Sampling frequency in Hz
+#define SAMPLE_FREQ                   1         // Sampling frequency in Hz
 
 // Burst sampling alternates between writing and sleeping according to set periods below
-const uint8_t writeSeconds = 5;    // Number of seconds to sample data in burst sampling
+const uint8_t writeSeconds = 1;    // Number of seconds to sample data in burst sampling
 
-const uint8_t sleepSeconds = 120;   // Number of seconds to sleep in burst sampling. Currently burst sampling only works if sleeping for at least 15 seconds
+const uint8_t sleepSeconds = 10;   // Number of seconds to sleep in burst sampling. Currently burst sampling only works if sleeping for at least 15 seconds
 
 // Edit for DELAY start ONLY
 #if DELAY_START // Date to start sampling
@@ -125,8 +125,8 @@ class CustomMS5803 : public MS5803 {
 #define ERROR_PAUSE_DELAY             200     // Pause between error blink cycles (ms)
 #define ERROR_BLINK_CYCLE             10      // Total blinks per error cycle
 
-const uint8_t LED_WARMUP_DEFAULT_FLASHES = 5;
-const uint16_t LED_WARMUP_MANUAL_FLASH_DELAY_MS = 500;
+const uint8_t LED_WARMUP_DEFAULT_FLASHES = 6;
+const uint16_t LED_WARMUP_MANUAL_FLASH_DELAY_MS = 100;
 
 // ADC and voltage definitions
 #define MAX_ADC_VALUE                 1024    // Maximum ADC reading (10-bit resolution)
@@ -135,14 +135,14 @@ const uint16_t LED_WARMUP_MANUAL_FLASH_DELAY_MS = 500;
 
 // Buffer and data definitions
 #define BUFFER_SIZE                   36      // Circular buffer size (limited by 32u4 SRAM, only 2560 bytes)
-#define BUFFER_WRITE_COUNT            32       // Buffer and data definitions 32
+#define BUFFER_WRITE_COUNT            32      // Buffer and data definitions 32
 #define FILENAME_LENGTH               13      // Filename length, limited by FAT16 filesystem to 8.3 format (13th char for null terminator)
 #define FRESHWATER_DENSITY            997     // Freshwater density (kg/m³) for pressure calculations
-#define SALTWATER_DENSITY            1025     // Saltwater density (kg/m³) for pressure calculations
+#define SALTWATER_DENSITY             1025    // Saltwater density (kg/m³) for pressure calculations
 
 // Error code definitions
 #define ERROR_SD_CARD_FAILED          1       // Error code for SD card initialization failure
-#define ERROR_FILE_OPEN_FAILED        5       // Error code for file creation failure
+#define ERROR_FILE_OPEN_FAILED        2       // Error code for file creation failure
 
 #define SERIAL_NUMBER_ADDRESS         0       // EEPROM address for device serial number
 
@@ -192,7 +192,8 @@ volatile bool deepSleepFlag  = false;
 volatile bool burstSleepFlag = false;
 volatile bool sleeping       = false;
 
-unsigned long millisAtInterrupt = 0; // Number of milliseconds at last 1 Hz interrupt from RTC
+// Number of milliseconds at last 1 Hz interrupt from RTC
+unsigned long millisAtInterrupt = 0; 
 
 // # of times the LED should be toggled (switched between on/off) during the start-up verification phase
 uint8_t ledWarmupToggleTarget = 0;
@@ -213,6 +214,7 @@ void setup() {
   pinMode(LED_PIN, OUTPUT); // Activates the red LED on pin 13
   configureLedWarmupIndicator();
   pinMode(RTC_INTERRUPT_PIN, INPUT_PULLUP);
+  Serial.end();
   // Serial.begin(SERIAL_BAUD_RATE);  // Commented out to prevent blocking when USB disconnected
   // while (!Serial);  // Removed to prevent blocking when USB disconnected 
   Wire.begin();
@@ -338,9 +340,9 @@ void setup() {
 
 void loop() {
     if (deepSleepFlag) {
-      digitalWrite(LED_PIN, HIGH);
+      // digitalWrite(LED_PIN, HIGH);
       // delay(3000);
-      digitalWrite(LED_PIN, LOW);
+      // digitalWrite(LED_PIN, LOW);
       deepSleepLog();
     }
     #if BURST_SAMPLING
@@ -360,9 +362,9 @@ void loop() {
         }
         burstSleepFlag = false;
       } else if (elapsed.totalseconds() > writeSeconds || BURST_SAMPLING_ONE_SAMPLE) {
-        digitalWrite(LED_PIN, HIGH);
-        delay(1);
-        digitalWrite(LED_PIN, LOW);
+        // digitalWrite(LED_PIN, HIGH);
+        // delay(1);
+        // digitalWrite(LED_PIN, LOW);
         #if BURST_SAMPLING_ONE_SAMPLE
           performSensorReading();
         #endif
@@ -781,9 +783,8 @@ void enterBurstDeepSleep(DateTime endTime) {
   rtc.setAlarm1(nextWake, DS3231_A1_Date);
   attachInterrupt(digitalPinToInterrupt(RTC_INTERRUPT_PIN), burstSleepInterrupt, FALLING);
 
-  // LowPower.idle(SLEEP_FOREVER, ADC_ON, TIMER4_ON, TIMER3_ON, TIMER1_OFF, TIMER0_OFF, SPI_OFF, USART1_OFF, TWI_OFF, USB_OFF);
   LowPower.powerDown(SLEEP_FOREVER, ADC_OFF, BOD_OFF);
-  delay(50);  // This delay is important to allow MCU components to stabilize
+  delay(50);  // This delay is important to allow MCU components to initialize upon wake-up
   Wire.end();
   Wire.begin();
   Wire.setClock(TWI_CLOCK_SPEED);
@@ -796,6 +797,7 @@ void enterBurstDeepSleep(DateTime endTime) {
     Timer1.attachInterrupt(triggerSampling); // Every time Timer1 finishes counting down, calls triggerSampling
   #endif
 }
+
 /**
  * setForeverIdleSleep
  * Purpose: Enter idle sleep indefinitely while keeping timers 0/1 running for millis tracking and sampling cadence.
@@ -804,7 +806,7 @@ void enterBurstDeepSleep(DateTime endTime) {
  */
 void setForeverIdleSleep() {
   // TODO: See if turning on SPI/TWI improves data loss
-  // ADC, timer 3, and timer 4 are set to ON so LowPower library doesn't accidentally turn them back on, they are already off
+  // ADC, timer 3, and timer 4 are set to ON so LowPower library doesn't turn them back on afer sleep, they are already off
   LowPower.idle(SLEEP_FOREVER, ADC_ON, TIMER4_ON, TIMER3_ON, TIMER1_ON, TIMER0_ON, SPI_OFF, USART1_OFF, TWI_ON, USB_OFF);
 }
 


### PR DESCRIPTION
Added LED flashing to the first ~12 samples to make it easier to verify the wave gauge is running without a serial connection
- LED will flash 6 times (turns on/off on each sample) if in continuous sampling
- In burst sampling mode, the number of flashes may be less than 6 if the write window is too small to contain 12 samples
- In single burst sampling mode, the LED flashes once for 100ms.