### PR TITLE
Refactor sensorWait and update library usage notes

### DIFF
--- a/Sketchbooks/feathergauge_code/SparkFun_MS5803_I2C.cpp
+++ b/Sketchbooks/feathergauge_code/SparkFun_MS5803_I2C.cpp
@@ -1,3 +1,6 @@
+// **IMPORTANT** This library should only be used with feathergauge_code.ino,
+// as it contains assumptions about processor state for sleep management.
+
 /******************************************************************************
 MS5803_I2C.cpp
 Library for MS5803 pressure sensor.
@@ -271,13 +274,17 @@ void MS5803::sendCommand(uint8_t command)
 	_i2cPort->endTransmission();
 }
 
-// Only one MS5803 should ever call sensorWait() at any time
+// IMPORTANT: This function REQUIRES timer0 to be tracking milliseconds to work correctly.
 // ADC_256 waits for 1 ms, ADC_512 3 ms, ADC_1024 4 ms, ADC_2048 6 ms, AD_4096 10 ms
 // time parameter is in ms
+// Note: Setting `USB_OFF` may impact serial connection when debugging
 void MS5803::sensorWait(uint8_t time) {
    delay(time);
-   // unsigned long start = millis();
-   // while (millis() - start < time) {
-   //    LowPower.idle(SLEEP_FOREVER, ADC_ON, TIMER4_ON, TIMER3_ON, TIMER1_ON, TIMER0_ON, SPI_OFF, USART1_OFF, TWI_OFF, USB_OFF);
-   // }
+   unsigned long start = millis();
+   while (millis() - start < time) {
+      // In this sketch timer 0 wakes CPU from idle after 1 ms regardless of sleep time
+      // Turn off everything except timer 0 (used for millis), timer 1 (used for sampling), and TWI (used to communicate with pressure sensor)
+      // ADC, timer 3, and timer 4 are set to ON so LowPower library doesn't turn them back on, they are already off
+      LowPower.idle(SLEEP_FOREVER, ADC_ON, TIMER4_ON, TIMER3_ON, TIMER1_ON, TIMER0_ON, SPI_OFF, USART1_OFF, TWI_ON, USB_OFF);
+   }
 }

--- a/Sketchbooks/feathergauge_code/feathergauge_code.ino
+++ b/Sketchbooks/feathergauge_code/feathergauge_code.ino
@@ -1,5 +1,5 @@
 // ===========================
-// USER DEFINED FLAGS: 
+// USER FLAGS: 
 // Please set the following three flags according to your sensor type and preferred collection type.
 // Type "true" (without quotes) or "false" (without quotes)
 // ===========================
@@ -67,26 +67,15 @@ constexpr uint8_t sleepSeconds = 10;  // Number of seconds to sleep in burst sam
 #include <TimerOne.h>
 #include <LowPower.h>
 
+// A note on using the SparkFun library:
+// This program uses a custom version of the SparkFun MS5803 with additional power optimizations
+// It REQUIRES the millis() macro from Arduino to be functioning
+
 #if USE_NEW_SENSOR
   #include "MS5837.h"
 #else
   #include "SparkFun_MS5803_I2C.h"
 #endif
-
-// A note on using the SparkFun library:
-// A very minor change to the SparkFun library is needed for this code to work. The sensorWait function in SparkFun_MS5803_I2C.h must be declared as virtual.
-// This change is used to override sensorWait for better power management.
-
-// Create custom MS5803 class to override sensorWait function for better power management
-class CustomMS5803 : public MS5803 {
-  public:
-    void sensorWait(uint8_t time) {
-      // sensorWait in SparkFun library is 1-10ms; the minimum sleep time is 16ms; In this sketch timer 0 wakes from idle after 1 ms regardless of sleep time
-      // Turn off everything except timer 0 (used for millis), timer 1 (used for sampling), and TWI (used to communicate with pressure sensor)
-      // ADC, timer 3, and timer 4 are set to ON so LowPower library doesn't accidentally turn them back on, they are already off
-      LowPower.idle(SLEEP_15MS, ADC_ON, TIMER4_ON, TIMER3_ON, TIMER1_ON, TIMER0_ON, SPI_OFF, USART1_OFF, TWI_ON, USB_OFF);
-    }
-};
 
 // Timer 4 PRR bit is currently not defined in iom32u4.h
 #ifndef PRTIM4
@@ -819,7 +808,9 @@ void enterDelayDeepSleep() {
   rtc.setAlarm1(startDateTime, DS3231_A1_Date); // Alarm 1 triggers at the start time
   rtc.setAlarm2(startDateTime, DS3231_A2_Hour); // Alarm 2 triggers every day, taking a sample to track when/if battery dies
   if (Serial) Serial.println(F("Entering delay deep sleep"));
-  LowPower.powerDown(SLEEP_FOREVER, ADC_OFF, BOD_OFF);
+  // LowPower libraries reenables peripheerals set to OFF, even if they were initially disabled
+  // ADC is currently disabled, so setting `ADC_ON` keeps it disabled even after waking up
+  LowPower.powerDown(SLEEP_FOREVER, ADC_ON, BOD_OFF);
 }
 
 void enterBurstDeepSleep(DateTime endTime) {


### PR DESCRIPTION
Primary change: Remove unused CustomMS5803 class, update sensorWait function in SparkFun class

The sensorWait function has been underutilized for some time, as timer0 interrupts for millis() tracking cutoff any idling longer than 1 second. This change eliminates spurious wakeups by using the millisecond timer to check if the requested wait time has actually elapsed and going back to sleep until it has.

This requires the timer0 to trigger interrupts every 1ms for correctness. This is acceptable, as many other parts of the program rely on these interrupts already.

Summary of changes:
- Simplified user-defined flags comment for clarity.
- Removed custom MS5803 class and related comments to streamline the code.
- Enhanced documentation regarding the SparkFun library and its requirements for proper functionality.
- Updated sensorWait function comments to clarify timing dependencies and power management.
- Added important notes on library usage and processor state assumptions for better guidance.